### PR TITLE
Replace `charts` property of simfiles with a plain instance member

### DIFF
--- a/simfile/base.py
+++ b/simfile/base.py
@@ -134,6 +134,9 @@ class BaseSimfile(OrderedDict, Serializable, metaclass=ABCMeta):
     keysounds = item_property('KEYSOUNDS')
     attacks = item_property('ATTACKS')
 
+    charts: BaseCharts
+    """List of charts associated with this simfile."""
+
     def __init__(self, *,
                  file: Optional[Union[TextIO, Iterator[str]]] = None,
                  string: Optional[str] = None,
@@ -176,13 +179,6 @@ class BaseSimfile(OrderedDict, Serializable, metaclass=ABCMeta):
             file.write(f'{param}\n')
         file.write('\n')
         self.charts.serialize(file)
-
-    @property
-    @abstractmethod
-    def charts(self):
-        """
-        List of charts associated with this simfile.
-        """
 
     def __repr__(self) -> str:
         """

--- a/simfile/sm.py
+++ b/simfile/sm.py
@@ -187,6 +187,8 @@ class SMSimfile(BaseSimfile):
                 self.charts.append(SMChart.from_msd(param.components[1:]))
             elif key in BaseSimfile.MULTI_VALUE_PROPERTIES:
                 self[key] = ':'.join(param.components[1:])
+            else:
+                self[key] = param.value
     
     @classmethod
     def blank(cls: Type['SMSimfile']) -> 'SMSimfile':

--- a/simfile/sm.py
+++ b/simfile/sm.py
@@ -172,21 +172,21 @@ class SMSimfile(BaseSimfile):
     """
     SM implementation of :class:`~simfile.base.BaseSimfile`.
     """
-    _charts: SMCharts
 
     # "FREEZES" alias only supported by SM files
     stops = item_property('STOPS', alias='FREEZES')
+    """
+    Specialized property for `STOPS` that supports `FREEZES` as an alias.
+    """
 
     def _parse(self, parser: MSD_ITERATOR):
-        self._charts = SMCharts()
+        self.charts = SMCharts()
         for param in parser:
             key = param.key.upper()
             if key == 'NOTES':
-                self._charts.append(SMChart.from_msd(param.components[1:]))
+                self.charts.append(SMChart.from_msd(param.components[1:]))
             elif key in BaseSimfile.MULTI_VALUE_PROPERTIES:
                 self[key] = ':'.join(param.components[1:])
-            else:                
-                self[key] = param.value
     
     @classmethod
     def blank(cls: Type['SMSimfile']) -> 'SMSimfile':
@@ -214,7 +214,3 @@ class SMSimfile(BaseSimfile):
             #KEYSOUNDS:;
             #ATTACKS:;
         """))
-    
-    @property
-    def charts(self) -> SMCharts:
-        return self._charts

--- a/simfile/ssc.py
+++ b/simfile/ssc.py
@@ -138,9 +138,7 @@ class SSCSimfile(BaseSimfile):
       `preview`
     * Gameplay events: `combos`, `speeds`, `scrolls`, `fakes`
     * Timing data: `warps`
-    """
-    _charts: SSCCharts
-    
+    """    
     version = item_property('VERSION')
     origin = item_property('ORIGIN')
     previewvid = item_property('PREVIEWVID')
@@ -200,7 +198,7 @@ class SSCSimfile(BaseSimfile):
         """))
 
     def _parse(self, parser: MSD_ITERATOR):
-        self._charts = SSCCharts()
+        self.charts = SSCCharts()
         partial_chart: Optional[SSCChart] = None
         for param in parser:
             key = param.key.upper()
@@ -210,15 +208,11 @@ class SSCSimfile(BaseSimfile):
                 value = param.value
             if key == 'NOTEDATA':
                 if partial_chart is not None:
-                    self._charts.append(partial_chart)
+                    self.charts.append(partial_chart)
                 partial_chart = SSCChart()
             elif partial_chart is not None:
                 partial_chart[key] = value
             else:
                 self[key] = value
         if partial_chart is not None:
-            self._charts.append(partial_chart)
-    
-    @property
-    def charts(self) -> SSCCharts:
-        return self._charts
+            self.charts.append(partial_chart)

--- a/simfile/tests/test_sm.py
+++ b/simfile/tests/test_sm.py
@@ -202,7 +202,3 @@ class TestSMSimfile(unittest.TestCase):
 
         unit.charts = SMCharts()
         self.assertEqual(0, len(unit.charts))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/simfile/tests/test_sm.py
+++ b/simfile/tests/test_sm.py
@@ -189,6 +189,19 @@ class TestSMSimfile(unittest.TestCase):
         # Inequality checks
         self.assertNotEqual(base, variants[1])
         self.assertNotEqual(base, variants[2])
+    
+    def test_charts(self):
+        unit = SMSimfile(string=testing_simfile())
+        
+        self.assertIsInstance(unit.charts, SMCharts)
+        self.assertEqual(7, len(unit.charts))
+        self.assertIsInstance(unit.charts[0], SMChart)
+        
+        unit.charts = unit.charts[:3]
+        self.assertEqual(3, len(unit.charts))
+
+        unit.charts = SMCharts()
+        self.assertEqual(0, len(unit.charts))
 
 
 if __name__ == '__main__':

--- a/simfile/tests/test_ssc.py
+++ b/simfile/tests/test_ssc.py
@@ -239,7 +239,3 @@ class TestSSCSimfile(unittest.TestCase):
 
         unit.charts = SSCCharts()
         self.assertEqual(0, len(unit.charts))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/simfile/tests/test_ssc.py
+++ b/simfile/tests/test_ssc.py
@@ -226,6 +226,19 @@ class TestSSCSimfile(unittest.TestCase):
         # Inequality checks
         self.assertNotEqual(base, variants[1])
         self.assertNotEqual(base, variants[2])
+    
+    def test_charts(self):
+        unit = SSCSimfile(string=testing_simfile())
+        
+        self.assertIsInstance(unit.charts, SSCCharts)
+        self.assertEqual(10, len(unit.charts))
+        self.assertIsInstance(unit.charts[0], SSCChart)
+        
+        unit.charts = unit.charts[:3]
+        self.assertEqual(3, len(unit.charts))
+
+        unit.charts = SSCCharts()
+        self.assertEqual(0, len(unit.charts))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #11. Since the old `charts` property just proxied the private instance member `_charts` before, this change is non-breaking. It allows the field to be overwritten with a new list, with tests to demonstrate the functionality.

Also cleaned up miscellaneous docs/tests.